### PR TITLE
Update publication build system to use Central Portal 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,11 @@
 
   <name>OME JAI</name>
   <description>Fork of Java Advanced Imaging ImageIO (deprecated).</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats/</url>
   <inceptionYear>2005</inceptionYear>
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
   <licenses>
     <license>
@@ -62,15 +62,15 @@
     <connection>scm:git:https://github.com/ome/ome-jai</connection>
     <developerConnection>scm:git:git@github.com:ome/ome-jai</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/ome/ome-jai</url>
+    <url>https://github.com/ome/ome-jai</url>
   </scm>
   <issueManagement>
-    <system>Trac</system>
-    <url>https://trac.openmicroscopy.org/ome</url>
+    <system>GitHub</system>
+    <url>https://github.com/ome/ome-jai/issues</url>
   </issueManagement>
   <ciManagement>
-    <system>Jenkins</system>
-    <url>https://ci.openmicroscopy.org/</url>
+    <system>GitHub</system>
+    <url>https://github.com/ome/ome-jai/actions</url>
   </ciManagement>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -54,23 +54,6 @@
     <contributor><name>Bjoern Thiel</name></contributor>
   </contributors>
 
-  <mailingLists>
-    <mailingList>
-      <name>OME-users</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</unsubscribe>
-      <post>ome-users@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-users/</archive>
-    </mailingList>
-    <mailingList>
-      <name>OME-devel</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</unsubscribe>
-      <post>ome-devel@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-devel/</archive>
-    </mailingList>
-  </mailingLists>
-
   <prerequisites>
     <maven>3.0.5</maven>
   </prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -89,16 +89,6 @@
     <system>Jenkins</system>
     <url>https://ci.openmicroscopy.org/</url>
   </ciManagement>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
   <properties>
     <!-- NB: Avoid platform encoding warning when copying resources. -->
@@ -331,24 +321,11 @@
       <id>release</id>
       <build>
         <plugins>
-          <!-- Stage releases with nexus -->
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-
           <!-- gpg release signing -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -358,6 +335,17 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <configuration>
           <failOnError>false</failOnError>
           <links>
-            <link>http://docs.oracle.com/javase/7/docs/api/</link>
+            <link>https://docs.oracle.com/javase/8/docs/api/</link>
           </links>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -101,13 +101,14 @@
 
     <plugins>
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.14.0</version>
         <!-- Require the Java 8 platform. -->
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>8</source>
+          <target>8</target>
+          <release>8</release>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
See https://central.sonatype.org/news/20250326_ossrh_sunset/ for more context as well as https://github.com/ome/ome-common-java/pull/101 and https://github.com/ome/ome-contributing/pull/37

- adjusts the release profile  to use `central-publishing-maven-plugin` and remove OSSRH repositories
- update `maven-compiler-plugin` to 3.14.0 and set the release target set to 8 - see https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html#usage-on-jdk-8
- remove or update outdated metadata