### PR TITLE
Replace usage of sun.security.action by PrivilegedAction

### DIFF
--- a/src/main/java/com/sun/media/imageioimpl/plugins/pnm/PNMImageReader.java
+++ b/src/main/java/com/sun/media/imageioimpl/plugins/pnm/PNMImageReader.java
@@ -108,6 +108,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.StringTokenizer;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import com.sun.media.imageioimpl.common.ImageUtil;
 
 /** This class is the Java Image IO plugin reader for PNM images.
@@ -128,8 +131,13 @@ public class PNMImageReader extends ImageReader {
 
     static {
         if (lineSeparator == null) {
-            String ls = (String)java.security.AccessController.doPrivileged(
-               new sun.security.action.GetPropertyAction("line.separator"));
+            String ls = AccessController.doPrivileged(
+                new PrivilegedAction<String>() {
+                    public String run() {
+                        return System.getProperty("line.separator");
+                    }
+                }
+            );
             lineSeparator = ls.getBytes();
         }
     }

--- a/src/main/java/com/sun/media/imageioimpl/plugins/pnm/PNMImageWriter.java
+++ b/src/main/java/com/sun/media/imageioimpl/plugins/pnm/PNMImageWriter.java
@@ -94,6 +94,9 @@ import java.io.IOException;
 
 import java.util.Iterator;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import javax.imageio.IIOImage;
 import javax.imageio.IIOException;
 import javax.imageio.ImageTypeSpecifier;
@@ -140,8 +143,13 @@ public class PNMImageWriter extends ImageWriter {
 
     static {
         if (lineSeparator == null) {
-            String ls = (String)java.security.AccessController.doPrivileged(
-               new sun.security.action.GetPropertyAction("line.separator"));
+            String ls = AccessController.doPrivileged(
+                new PrivilegedAction<String>() {
+                    public String run() {
+                        return System.getProperty("line.separator");
+                    }
+                }
+            );
             lineSeparator = ls.getBytes();
         }
     }


### PR DESCRIPTION
See https://docs.oracle.com/javase/8/docs/api/java/security/AccessController.html This should address compilation errors of type "package sun.security.action does not exist"

See https://github.com/ome/ome-jai/pull/8#issuecomment-3000979919